### PR TITLE
feat: Added 8th bit as dealer held down during boot. Updated docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,18 @@ The driver implements a character buffer interface at `/dev/spcd0` that supports
 
 ### Inputs
 Reads occur one byte at a time. Each byte is a packed bitmask.
+The high bit, (bit 7) is set at power-on as a one-shot read of the dealer_enable during driver initialization. 
+If it's high, then the software should start into 'dealer' mode.
 ```
-     X  X  preboot_stat
-     |  |  |  12v
-     |  |  |  |  failsafe
-     |  |  |  |  |  valve_open
-     |  |  |  |  |  |  overpressure
-     |  |  |  |  |  |  |  stuck_on
-     |  |  |  |  |  |  |  |  dealer_enable
-     |  |  |  |  |  |  |  |  |
-Bit: 8  7  6  5  4  3  2  1  0
+     X  preboot_stat
+     |  |  12v
+     |  |  |  failsafe
+     |  |  |  |  valve_open
+     |  |  |  |  |  overpressure
+     |  |  |  |  |  |  stuck_on
+     |  |  |  |  |  |  |  dealer_enable
+     |  |  |  |  |  |  |  |
+Bit: 7  6  5  4  3  2  1  0
 ```
 
 ### Control Commands
@@ -78,13 +80,6 @@ The following files are read/write and will respond to `0` or `1` being written 
 pwr_hold
 postboot_stat
 one_min
-```
-
-Additionally, there is a 'buzzer' file that works with `0`, `1`, `2`, `3`, where 0 is off and 3 is high.
-Example: To set the buzzer to medium and turn it off again:
-```
-echo "2" > /sys/bus/platform/devices/spcd@0/buzzer
-echo "0" > /sys/bus/platform/devices/spcd@0/buzzer
 ```
 
 #### PWM:

--- a/spcd.c
+++ b/spcd.c
@@ -668,6 +668,8 @@ static int spcd_open(struct inode *inode, struct file *filp) {
     }
 
     filp->private_data = spcd_data;
+    // Make the first read() emit the current state of the device.
+    spcd_data->input_dirty = true;
     return 0;
 }
 
@@ -775,7 +777,7 @@ ssize_t spcd_read(struct file *filp, char __user *buf, size_t count, loff_t *pos
     ssize_t readlen = 1;
     u8 state = 0x00;
 
-    // If the data hasn't changes, return that we should try again later.
+    // If the data hasn't changed since the last read, return that we should try again later.
     if (spcd_data->input_dirty == false) {
         return -EAGAIN;
     }


### PR DESCRIPTION
This allows spcdcontrol to read (at any time) from the spcd device and determine if the boot switch was held down during boot.